### PR TITLE
FEAT: Feature/editor reviews detail for mobile

### DIFF
--- a/static_devs/css/editor_reviews/editor_reviews_detail.css
+++ b/static_devs/css/editor_reviews/editor_reviews_detail.css
@@ -86,6 +86,7 @@
     overflow-x: scroll;
     overflow-y: hidden;
     white-space: nowrap;
+    display: flex;
 }
 
 #product_img {
@@ -172,6 +173,10 @@
 
 #farm-news {
     margin-top: 15px;
+}
+
+#farm-news-mobile {
+    display: none;   
 }
 
 #farm-news-icon {

--- a/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
+++ b/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
@@ -31,6 +31,82 @@
     margin-top: 2.4rem;
   }
 
+  /* info section */
+  #info-section {
+    margin-top: 6.43rem;
+  }
+  /* info section - editor profile */
+  #editor-profile-image {
+    height: 2.65rem;
+    width: 2.65rem;
+    border: 1px solid #707070;
+  }
+  #editor-profile-name {
+    margin-right: 2.1rem;
+  }
+
+  /* info section - related products*/
+  #related_products {
+    margin-bottom: 5.84rem;
+  }
+  #related_products_desc {
+    margin-top: 2.67rem;
+    margin-bottom: 2.54rem;
+  }
+  #related_products_desc, 
+  #visit_farmer_desc {
+    align-items: center;
+  }
+  #related_products_desc > img,
+  #visit_farmer_desc > img {
+    width: 1.75rem;
+    height: 1.99rem;
+  }
+  #products {
+    display: flex;
+    width: 90%;
+    margin: 0 1.7rem;
+  }
+  #product_item {
+    min-width: 12.6rem;
+  }
+  #product_item > div {
+    margin-top: 0;
+  }
+  #product_img {
+    width: 11rem;
+    height: 16rem;
+    border-radius: 0.33rem;
+    box-shadow: none;
+    margin-right: 1.6rem;
+  }
+  #like_cart_in {
+    top: 15.08rem;
+    right: 1.7rem;
+  }
+  #like_cart_in img {
+    width: 1.6rem;
+    height: 1.6rem;
+    margin-left: 0.39rem;
+    transform: scale(1);
+  }
+  #product_item > a > div {
+    margin-top: 0.93rem;
+  }
+  #product_item > a > div > div {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .border-l-2 {
+    display: none;
+  }
+  #sub_title {
+    padding-left: 0;
+  }
+  #sell_price {
+    margin-top: 0.2rem;
+  }
+
   /* font */    
   #review-title {
     font-size: 2rem;
@@ -89,6 +165,7 @@
     font-size: 1.2rem;
     line-height: 1.2;
     font-weight: 500;
+    height: 1.6rem;
   }
   #farm-info,
   #farm-location {

--- a/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
+++ b/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
@@ -1,0 +1,93 @@
+@import 'base/mobile_base_style.css';
+
+@media screen and (max-width: 768px){
+  /* base setting */
+  #main {
+      width: 100%;
+      padding: 0;
+  }  
+  #main > div{
+      width: 100%;
+  }
+  #content-section,
+  #info-section,
+  #comment-section-wrap {
+      padding: 0 2.5rem;
+  }  
+
+  /* font */    
+  #review-title {
+    font-size: 2rem;
+    font-weight: 500;
+    margin-top: 3.53rem;
+    line-height: 1.2;
+  }
+  #review-subtitle {
+    font-size: 1.2rem;
+    font-weight: normal;
+    line-height: 1.2;
+    margin-top: 1vw;
+  }
+  #review-author {
+    font-size: 1.2rem;
+    margin-top: 6.18rem;
+    font-weight: normal;
+    line-height: 1.2;
+  }
+  #content-section {
+    font-size: 1.6rem;
+    font-weight: normal;
+    line-height: 1.47;
+    color: #4d4d4d;
+  }
+  #editor-profile-name {
+    font-size: 1.2rem;
+    margin-left: 0.79rem;
+    color: #4d4d4d;
+    font-weight: 300;
+    line-height: 2;
+  }
+  #desc_title {
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin-left: 1.09rem;
+  }
+  #title {
+    font-size: 1.2rem;
+    font-weight: 300;
+    line-height: 1.2;
+    color: #000000;
+  }
+  #sub_title {
+    font-size: 1.2rem;
+    font-weight: 500;
+    line-height: 1.2;
+    color: #000000;
+  }
+  #sell_price {
+    font-size: 1.5rem;
+    font-weight: 500;
+    line-height: 1.2;
+  }
+  #farm-profile-title {
+    font-size: 1.2rem;
+    line-height: 1.2;
+    font-weight: 500;
+  }
+  #farm-info,
+  #farm-location {
+    font-size: 1.2rem;
+    line-height: 1.2;
+    font-weight: 500;
+  }
+  #farm-name {
+    font-size: 1.5rem;
+    line-height: 1.2;
+    font-weight: bold;
+  }
+  #farm-news-text {
+    font-size: 1.2rem;
+    line-height: 1.33;
+    font-weight: 300;
+  }
+}

--- a/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
+++ b/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
@@ -63,7 +63,6 @@
     height: 1.99rem;
   }
   #products {
-    display: flex;
     width: 90%;
     margin: 0 1.7rem;
   }
@@ -105,6 +104,55 @@
   }
   #sell_price {
     margin-top: 0.2rem;
+  }
+
+  /* info section - visit farmer */
+  #visit_farmer_desc {
+    margin-bottom: 2.66rem;
+  }
+  #farmer_profile {
+    width: 6.36rem;
+    height: 6.36rem;
+    margin-left: 1.73rem;
+  }
+  #pick_img {
+    display: none;
+  }
+  #farm-desc {
+    margin-left: 0.93rem;
+  }
+  #farm-profile-title {
+    margin-top: 0.22rem;
+  }
+  #farm-info {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-top: 0.84rem;
+    height: fit-content;
+  }
+  #farm-name {
+    margin-left: 0;
+    margin-top: 0.1rem;
+  }
+  #visit {
+    width: 4.8rem;
+    height: 4.8rem;
+    margin-right: 1.87rem;
+  }
+  #farm-news {
+    display: none;
+  }
+  #farm-news-mobile {
+    display: flex;
+  }
+  #farm-news-icon {
+    width: 1.3rem;
+    margin-left: 3.1rem;
+  }
+  #farm-news-text {
+    margin-left: 1.25rem;
+    margin-right: 3.25rem;
+    margin-top: 1.46rem;
   }
 
   /* font */    

--- a/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
+++ b/static_devs/css/editor_reviews/editor_reviews_detail_mobile.css
@@ -15,6 +15,22 @@
       padding: 0 2.5rem;
   }  
 
+  /* top section */
+  #top-section {
+    height: 19rem;
+    margin-top: 6.2rem;
+  }
+  #review-arrow {
+    margin-top: 0.72rem;
+    width: 1.98rem;
+    height: 1.1rem;
+  }
+
+  /* content section */
+  #content-section {
+    margin-top: 2.4rem;
+  }
+
   /* font */    
   #review-title {
     font-size: 2rem;

--- a/templates/editor_reviews/detail/editor_reviews_detail.html
+++ b/templates/editor_reviews/detail/editor_reviews_detail.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% block stylesheet %}
 <link rel="stylesheet" href="{% static 'css/editor_reviews/editor_reviews_detail.css' %}">
+<link rel="stylesheet" href="{% static 'css/editor_reviews/editor_reviews_detail_mobile.css' %}">
 {% endblock stylesheet %}
 {% block title_name %}{{review.title}} : Editor's Pick{% endblock %}
 {% block og_url %}{% url 'editors_pick:detail' review.pk %}{% endblock %}

--- a/templates/editor_reviews/detail/info_section.html
+++ b/templates/editor_reviews/detail/info_section.html
@@ -82,6 +82,10 @@
                     <img src="{% static 'images/editors_review/editor_review_detail_visit_farm.svg'%}" id="visit">
                 </a>
             </div>
+            <div id="farm-news-mobile" class="flex items-center">
+                <img src="{% static 'images/product_detail/bell.svg' %}" id="farm-news-icon">
+                <div id="farm-news-text">{{review.farm.farm_news}}</div>
+            </div>
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
#farm-news-icon은 제플린에서 모바일(이벤트 관련 - 에디터스픽 페이지 1) 과 웹(피키팜1 - 에디터 글 상세페이지) 아이콘이 동일하여 이미지 변경 없이 bell로 두었습니다. 모바일 환경에서의 이미지 변경이 필요하면 말씀해주세요.