### PR TITLE
[ ] 비회원 결제 화면 문구 추가

### DIFF
--- a/templates/orders/payment_non_user.html
+++ b/templates/orders/payment_non_user.html
@@ -7,7 +7,7 @@
 {% endblock stylesheet %}
 
 {% block title_name %}
-피키팜 | 결제 진행
+피키팜 | 비회원 결제 진행
 {% endblock title_name %}
 
 {% block main_content %}
@@ -17,7 +17,8 @@
 
     {% csrf_token %}
     <div id="title-section">
-        <p id="title-text">주문서 작성 / 결제</p>
+        <p id="title-text">비회원 결제</p>
+        <p>회원이신 분은 로그인 후 회원 구매해주세요!</p>
         <div id="requried-section" class="flex flex-row justify-end">
             <img src="{% static 'images/orders/dot.svg' %}">
             <div id="required-text">필수입력사항</div>


### PR DESCRIPTION
## 📝 PR Summary
<!-- -->
 비회원 결제 화면 문구 추가

#### 🌲 Working Branch
<!--  -->
hotfix/non-user-payment-uxui

#### 🌲 TODOs
<!-- 해당 PR에서 했던 작업을 나열한다 -->
- 회원 고객들중 비회원 구매시 회원구매로 착각하고 구매하는 경우가 있어서 안내 문구 임시로 추가
- "회원이신 분은 로그인 후 회원 구매 해주세요"
- "주문서 작성 / 결제" -> "비회원 결제"

### Related Issues
<!-- *해당 PR에 연관된 이슈를 멘션한다* -->
- resolves #
