### PR TITLE
[#74] 주문관련 알림톡 재전송 admin action

### DIFF
--- a/orders/admin.py
+++ b/orders/admin.py
@@ -31,6 +31,12 @@ class CustomOrderGroupAdmin(admin.ModelAdmin):
         "create_at",
     )
 
+    list_filter = ('consumer_type', 'order_type')
+
+    
+
+
+
 
 class OrderDetailFarmerFilter(SimpleListFilter):
     title = "농가 기준으로 필터링"
@@ -80,6 +86,7 @@ class CustomOrderDetailAdmin(admin.ModelAdmin):
         "payment_status_progress",
         "payment_status_done",
         "calculate_amount",
+        'send_delivery_start_message_to_consumer'
     ]
 
     # change_list_template = "admin/orders/order_detail/change_list.html"
@@ -248,10 +255,63 @@ class CustomOrderDetailAdmin(admin.ModelAdmin):
         else:
             self.message_user(request, f"[정산 진행] 상태가 아닌 주문이 있습니다. : {fail_list}", messages.ERROR)
 
+    def send_delivery_start_message_to_consumer(self, request, queryset):
+        ''' 소비자에게 배송시작 알림톡 재 전송 ADMIN ACTION '''
+        passed_order = 0 # 전송하지 않은 주문 건수 카운트
+
+        for order in queryset:
+            if order.status != 'shipping':
+                passed_order += 1
+                continue
+
+            order_group = order.order_group
+
+            # 카카오 알림톡 전송을 위한 결제자 번호
+            phone_number_consumer = order_group.orderer_phone_number
+            print(f"[송장 입력 팝업 - POST] Consumer phone number : {phone_number_consumer}")
+
+            # 주문 상품
+            product = order.product
+            # 파머
+            farmer = product.farmer
+
+            kakao_msg_weight = (str)(product.weight) + product.weight_unit
+
+            kakao_msg_quantity = (str)(order.quantity) + "개"
+
+            args_consumer = {
+                "#{order_detail_title}": product.title,
+                "#{farmer_nickname}": farmer.user.nickname,
+                "#{option_name}": product.option_name,
+                "#{quantity}": kakao_msg_quantity,
+                "#{shipping_company}": order.get_delivery_service_company_display(),
+                "#{invoice_number}": order.invoice_number,
+            }
+
+            # 소비자 결제 완료 카카오 알림톡 전송
+            send_kakao_message(
+                phone_number_consumer,
+                templateIdList["delivery_start"],
+                args_consumer,
+            )
+
+
+            # 선물하기 결제인 경우 선물 받는 사람 번호
+            if order_group.order_type == "gift":
+                phone_number_gift_rev = order.rev_phone_number_gift
+                send_kakao_message(
+                    phone_number_gift_rev,
+                    templateIdList["delivery_start"],
+                    args_consumer,
+                )
+            
+        self.message_user(request, f"{len(queryset)}건의 주문 중 배송중이 아닌 {passed_order}건의 주문을 제외한 {len(queryset) - passed_order}건의 주문에 메시지를 전송했습니다.", messages.SUCCESS)
+
     order_complete.short_description = "[주문관리] 배송 완료 처리"
     payment_status_progress.short_description = "[정산관리] 정산 진행 처리"
     payment_status_done.short_description = "[정산관리] 정산 완료 처리"
     calculate_amount.short_description = "[정산 관리] 정산 진행 항목 정산 금액 계산"
+    send_delivery_start_message_to_consumer.short_description = '[주문관리] 소비자에게 배송 시작 알림톡 전송'
 
 
 @admin.register(models.RefundExchange)


### PR DESCRIPTION
## 📝 PR Summary
배송 시작 알림톡 전송 admin action 구현

#### 🌲 Working Branch
<!-- 작업했던 브랜치 명을 적는다 (추후 Jira 티켓 번호로 대체될 수 있음) -->
`feature/order_admin_send_kakao_msg`

#### 🌲 TODOs
<!-- 해당 PR에서 했던 작업을 나열한다 -->
- `Order_Group` admin 페이지에서 회원/비회원 필터링
- `Order_Group` admin 페이지에서 일반구매/선물하기 필터링
- `Order_Detail` admin 페이지에서 배송 시작 알림톡 전송 admin action 구현

### Related Issues
<!-- *해당 PR에 연관된 이슈를 멘션한다* -->
- resolves #74 

### Remarks
- 알림톡 전송후 해당 함수 삭제 예정
