### PR TITLE
[#74] 배송시작 알림톡 admin action 삭제

### DIFF
--- a/orders/admin.py
+++ b/orders/admin.py
@@ -251,71 +251,10 @@ class CustomOrderDetailAdmin(admin.ModelAdmin):
         else:
             self.message_user(request, f"[정산 진행] 상태가 아닌 주문이 있습니다. : {fail_list}", messages.ERROR)
 
-    def send_delivery_start_message_to_consumer(self, request, queryset):
-        """소비자에게 배송시작 알림톡 재 전송 ADMIN ACTION"""
-        passed_order = 0  # 전송하지 않은 주문 건수 카운트
-        user_order = 0
-
-        for order in queryset:
-            if order.status != "shipping":
-                passed_order += 1
-                continue
-
-            if order.order_group.consumer_type == "user":
-                user_order += 1
-                continue
-
-            order_group = order.order_group
-
-            # 카카오 알림톡 전송을 위한 결제자 번호
-            phone_number_consumer = order_group.orderer_phone_number
-            print(f"[송장 입력 팝업 - POST] Consumer phone number : {phone_number_consumer}")
-
-            # 주문 상품
-            product = order.product
-            # 파머
-            farmer = product.farmer
-
-            kakao_msg_weight = (str)(product.weight) + product.weight_unit
-
-            kakao_msg_quantity = (str)(order.quantity) + "개"
-
-            args_consumer = {
-                "#{order_detail_title}": product.title,
-                "#{farmer_nickname}": farmer.user.nickname,
-                "#{option_name}": product.option_name,
-                "#{quantity}": kakao_msg_quantity,
-                "#{shipping_company}": order.get_delivery_service_company_display(),
-                "#{invoice_number}": order.invoice_number,
-            }
-
-            # 소비자 결제 완료 카카오 알림톡 전송
-            send_kakao_message(
-                phone_number_consumer,
-                templateIdList["delivery_start"],
-                args_consumer,
-            )
-
-            # 선물하기 결제인 경우 선물 받는 사람 번호
-            if order_group.order_type == "gift":
-                phone_number_gift_rev = order.rev_phone_number_gift
-                send_kakao_message(
-                    phone_number_gift_rev,
-                    templateIdList["delivery_start"],
-                    args_consumer,
-                )
-
-        self.message_user(
-            request,
-            f"총 주문 {len(queryset)}건, 배송중이 아닌 주문 {passed_order}건, 회원 주문 {user_order}건, 발송 {len(queryset) - passed_order}건",
-            messages.SUCCESS,
-        )
-
     order_complete.short_description = "[주문관리] 배송 완료 처리"
     payment_status_progress.short_description = "[정산관리] 정산 진행 처리"
     payment_status_done.short_description = "[정산관리] 정산 완료 처리"
     calculate_amount.short_description = "[정산 관리] 정산 진행 항목 정산 금액 계산"
-    send_delivery_start_message_to_consumer.short_description = "[주문관리] 소비자에게 배송 시작 알림톡 전송"
 
 
 @admin.register(models.RefundExchange)


### PR DESCRIPTION
## 📝 PR Summary
배송 시작 알림톡 전송 admin action 삭제

#### 🌲 Working Branch
<!-- 작업했던 브랜치 명을 적는다 (추후 Jira 티켓 번호로 대체될 수 있음) -->
`feature/order_admin_send_kakao_msg`

#### 🌲 TODOs
<!-- 해당 PR에서 했던 작업을 나열한다 -->
- `Order_Detail` admin 페이지에서 배송 시작 알림톡 전송 admin action 삭제

### Related Issues
<!-- *해당 PR에 연관된 이슈를 멘션한다* -->
- resolves #74 

### Remarks
- 추후 admin 에서 누락 알림톡을 전송하는 action을 구현할 예정
