### PR TITLE
[#71] 상품가격 천단위 comma 적용

### DIFF
--- a/templates/products/product_detail.html
+++ b/templates/products/product_detail.html
@@ -4,6 +4,7 @@
 {% block og_desc %}{{product.sub_title}}{% endblock %}
 {% block og_image %}{{product.main_image.url}}{% endblock %}
 {% block title_name %}{{product.title}}{% endblock %}
+{% load humanize %}
 
 {% load static %}
 {% block stylesheet %}
@@ -79,7 +80,7 @@
                 </div>
             </div>
             <div id="cost" class="pt-8 pb-6 mb-2">
-                {{product.sell_price}}원
+                {{product.sell_price | intcomma}}원
             </div>
 
             <div id="farmer_section" class="flex flex-row items-center mt-3">
@@ -104,7 +105,7 @@
             <div id="info_section" class="border-b mt-12 pt-5 pb-5">
                 <div class="flex flex-rows">
                     <div id="info_t" class="w-1/5 text-left">배송비</div>
-                    <div id="shipping-fee" class="w-4/5 text-left text-red-500">{{product.default_delivery_fee}}원</div>
+                    <div id="shipping-fee" class="w-4/5 text-left text-red-500">{{product.default_delivery_fee | intcomma}}원</div>
                 </div>
                 <div id="shipping-fee-desc" class="mb-3">
                     {{product.additional_delivery_fee_unit}}개 마다 추가 배송비 부과 / 제주 외 도서지역 추가 배송비 추가
@@ -194,6 +195,11 @@
 
 
 <script>
+
+    function removeCommaInStringifiedNumber(num) {
+        return parseInt(num.replace(/,/g, "")) // remove comma using regex
+     }
+
     // 구독하기
     const subBtn = document.getElementById('sub')
     const subURL = "{% url 'users:subs' %}"
@@ -219,12 +225,14 @@
     let title = document.getElementById("title")
     let subTitle = document.getElementById("subtitle")
 
-    let cost = document.getElementById("cost")
+    let costStr = document.getElementById("cost").innerHTML
+    let cost = removeCommaInStringifiedNumber(costStr)
     let totalCost = document.getElementById("total_price")
 
     let quantityNumber = document.getElementById("quantity_number")
 
-    let shippingFee = document.getElementById("shipping-fee")
+    let shippingFeeStr = document.getElementById("shipping-fee")
+    let shippingFee = removeCommaInStringifiedNumber(shippingFeeStr)
     let shippingFeeDesc = document.getElementById("shipping-fee-desc")
     let weight = document.getElementById("product-weight")
 

--- a/templates/products/products_list.html
+++ b/templates/products/products_list.html
@@ -4,7 +4,7 @@
 {% block og_desc %}피키팜의 무난이들을 만나보세요{% endblock %}
 {% block og_image %}{{products.first.main_image.url}}{% endblock %}
 {% block title_name %}상품목록{% endblock %}
-
+{% load humanize %}
 
 {% load static %}
 {% block stylesheet %}
@@ -119,7 +119,7 @@
                         <a href="{% url 'products:product_detail' product.get_main_product.pk %}" class="">
                             <div class="mt-1">
                                 <p class="" id="title">{{product.title}}</p>
-                                <p class="" id="sell_price">{{product.get_main_product.sell_price}}원</p>
+                                <p class="" id="sell_price">{{product.get_main_product.sell_price | intcomma}}원</p>
                                 <p class="" id="sub_title">{{product.sub_title}}</p>
                             </div>
                         </a>

--- a/templates/users/mypage_carts.html
+++ b/templates/users/mypage_carts.html
@@ -6,6 +6,8 @@
 <link rel="stylesheet" href="{% static 'css/users/mypage/user/mypage_carts_mobile.css' %}">
 {% endblock stylesheet_detail %}
 
+{% load humanize %}
+
 {% block content %}
 {% if carts.exists is True %}
 <div id="filter-section" class="flex flex-row">
@@ -45,7 +47,7 @@
                 <div class="flex flex-row mt-2">
                     <div id="product_weight">{{cart.product.weight}}g / </div>
                     <div id="product_price_{{cart.product.pk}}" class="product_price" name="{{cart.product.sell_price}}">
-                        {{cart.product.sell_price}}원</div>
+                        {{cart.product.sell_price | intcomma}}원</div>
 
                 </div>
 
@@ -98,6 +100,9 @@
 <script type="text/javascript" src="http://code.jquery.com/jquery-2.1.4.js"></script>
 <script>
 
+    function removeCommaInStringifiedNumber(num) {
+        return parseInt(num.replace(/,/g, "")) // remove comma using regex
+     }
 
     let menuBtns = []
     menuBtns.push(document.getElementById('menu_boughts'))

--- a/templates/users/mypage_orders.html
+++ b/templates/users/mypage_orders.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="{% static 'css/users/mypage/user/mypage_orders_mobile.css' %}">
 {% endblock stylesheet_detail %}
 
-
+{% load humanize %}
 
 {% block content %}
 {% if order_details_exist == 0 %}
@@ -53,7 +53,7 @@
 
       </div>
       <div class="flex flex-row">
-        <div id="product_price">{{detail.total_price}}원</div>
+        <div id="product_price">{{detail.total_price | intcomma}}원</div>
         <div id="product_quantity">{{detail.quantity}}개</div>
       </div>
       <div class="flex flex-row" id="delivery_status">

--- a/templates/users/mypage_wishes.html
+++ b/templates/users/mypage_wishes.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="{% static 'css/users/mypage/user/mypage_wishes.css' %}">
 <link rel="stylesheet" href="{% static 'css/users/mypage/user/mypage_wishes_mobile.css' %}">
 {% endblock stylesheet_detail %}
-
+{% load humanize %}
 {% block content %}
 
 {% if wishes.exists is False %}
@@ -46,7 +46,7 @@
                 </div>
                 <div class="flex flex-row mt-2"> 
                     <div id="product_weight">{{wish.product.weight}}g <span>/</span> </div>
-                    <div id="product_price"> {{wish.product.sell_price}}원</div>
+                    <div id="product_price"> {{wish.product.sell_price | intcomma}}원</div>
 
                 </div>
 


### PR DESCRIPTION
## 📝 PR Summary
<!-- PR을 한 줄로 요약하여 적는다 -->
상품 가격 천단위 humanize intcomma 적용

#### 🌲 Working Branch
<!-- 작업했던 브랜치 명을 적는다 (추후 Jira 티켓 번호로 대체될 수 있음) -->
hotfix/price_comma

#### 🌲 TODOs
<!-- 해당 PR에서 했던 작업을 나열한다 -->
- 상품 상세 가격 표기 
- ---> js 변수 기준 cost와 shippingFee에 removeCommasInStringifiedNumber 메소드 적용 
- ---> 주문 개수에 따라 동적으로 변하는 최종 주문금액에는 적용하지 않았음 
- 상품 스토어 리스트 가격 천단위 표기 적용
- 마이페이지 가격 표기 (주문내역, 장바구니 - 총주문금액(동적)은 제외, 찜한목록)
- ---> 상품 상세와 마찬가지로, 장바구니의 동적인 파트인 총주문금액에는 적용하지 않았음

### Related Issues
<!-- *해당 PR에 연관된 이슈를 멘션한다* -->
- resolves #71 
- @S-J-Kim 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 
- @S-J-Kim js로 인해 동적으로 바뀌는 부분에 대한 천단위 표기 방법은 다시 생각해봐야 할 것 같습니다. 위에 명시해놓은 대로 해당 부분은 모두 intcomma 적용하지 않았습니다.
