### PR TITLE
[#105] 선물하기 Order_Group order_at 필드 오류

### DIFF
--- a/orders/views.py
+++ b/orders/views.py
@@ -1548,6 +1548,7 @@ def payment_valid_gift(request):
                     detail.send_kakao_msg_order_for_farmer(is_gift=True)
 
             order_group.status = "payment_complete"
+            order_group.order_at = timezone.now()
             order_group.save()
 
 


### PR DESCRIPTION
## 📝 PR Summary
<!-- PR을 한 줄로 요약하여 적는다 -->
선물하기의 경우 Order_Group의 order_at이 값이 비어있는 상태 해결

#### 🌲 Working Branch
<!-- 작업했던 브랜치 명을 적는다 (추후 Jira 티켓 번호로 대체될 수 있음) -->
hotfix/gift_payment_ordergroup

#### 🌲 TODOs
<!-- 해당 PR에서 했던 작업을 나열한다 -->
- order_at field 값 업데이트

### Related Issues
<!-- *해당 PR에 연관된 이슈를 멘션한다* -->
- resolves #105 
